### PR TITLE
Fix to Firefox blob construction that was creating invalid files from recordings

### DIFF
--- a/RecordRTC/RecordRTC.js
+++ b/RecordRTC/RecordRTC.js
@@ -148,7 +148,13 @@ function MediaStreamRecorder(mediaStream) {
         // https://wiki.mozilla.org/Gecko:MediaRecorder
         mediaRecorder = new MediaRecorder(mediaStream);
         mediaRecorder.ondataavailable = function(e) {
-            self.recordedBlob = new Blob([self.recordedBlob, e.data], { type: 'audio/ogg' });
+			   if(self.recordedBlob) {
+					dataSource = [self.recordedBlob,e.data];
+				}
+				else {
+					dataSource = [e.data]
+				}
+            self.recordedBlob = new Blob(dataSource, { type: 'audio/ogg' });
         };
 
         mediaRecorder.start(0);


### PR DESCRIPTION
Checks to see if self.recordedBlob exists or not before including it in the data to pass to the blob.  Was causing the string "undefined" to appear at the beginning of files, making them unplayable, in Firefox 25+
