### PR TITLE
Fix record audio on new stream

### DIFF
--- a/RecordRTC/RecordRTC.js
+++ b/RecordRTC/RecordRTC.js
@@ -799,10 +799,7 @@ function StereoAudioRecorder(mediaStream, root) {
     var volume = Storage.VolumeGainNode;
 
     // creates an audio node from the microphone incoming stream
-    if (!Storage.AudioInput)
-        Storage.AudioInput = context.createMediaStreamSource(mediaStream);
-
-    var audioInput = Storage.AudioInput;
+    var audioInput = context.createMediaStreamSource(mediaStream);
 
     // connect the stream to the gain node
     audioInput.connect(volume);


### PR DESCRIPTION
When you have recorded audio once and close stopped media stream and then requested media stream again and try to record audio it fails with empty audio file because new audio input doesn't creates.
