### PR TITLE
Workaround for Android

### DIFF
--- a/RecordRTC/RecordRTC.js
+++ b/RecordRTC/RecordRTC.js
@@ -1753,6 +1753,11 @@ function WhammyRecorder(mediaStream) {
 
     function drawFrames() {
         var duration = new Date().getTime() - lastTime;
+        
+        // Tweak for Android Chrome
+        if(video.paused)
+            video.play();
+            
         if (!duration) {
             return drawFrames();
         }


### PR DESCRIPTION
Video is paused after WhammyRecorder.record() call in Chrome for Android. This workaround force video playing if it's needed