### PR TITLE
Stop file-sharing if the RTCDataChannel has been closed.

### DIFF
--- a/DetectRTC/DetectRTC.js
+++ b/DetectRTC/DetectRTC.js
@@ -833,9 +833,9 @@
 
     var displayResolution = '';
     if (screen.width) {
-        var width = (screen.width) ? screen.width : '';
-        var height = (screen.height) ? screen.height : '';
-        displayResolution += '' + width + ' x ' + height;
+        DetectRTC.displayResolutionWidth = (screen.width) ? screen.width : '';
+        DetectRTC.displayResolutionHeight = (screen.height) ? screen.height : '';
+        displayResolution += '' + DetectRTC.displayResolutionWidth + ' x ' + DetectRTC.displayResolutionHeight;
     }
     DetectRTC.displayResolution = displayResolution;
 

--- a/file-hangout/index.html
+++ b/file-hangout/index.html
@@ -142,7 +142,8 @@
 		
         <!-- Copy these two files! -->
         <script src="https://www.webrtc-experiment.com/firebase.js"> </script>
-        <script src="https://www.webrtc-experiment.com/file-hangout/file-hangout.js" async> </script>
+<!--         <script src="https://www.webrtc-experiment.com/file-hangout/file-hangout.js" async> </script> -->
+        <script src="file-hangout.js" async> </script>
     
         <a href="https://github.com/muaz-khan/WebRTC-Experiment/tree/master/file-hangout" class="fork-left"></a>
         


### PR DESCRIPTION
Currently I see continuing of sending of the file if receiver side was
closed. For testing close a joined to Group web page during sending /
receiving of the shared file.

I think, good idea to detect the readyState = 'closed ' of the
RTCDataChannel for stopping of sending of the file.