### PR TITLE
Update package.json

### DIFF
--- a/gumadapter/package.json
+++ b/gumadapter/package.json
@@ -12,6 +12,7 @@
     "type": "git",
     "url": "https://github.com/muaz-khan/gumadapter.git"
   },
+  "main": "gumadapter.js",
   "keywords": [
     "webrtc",
     "recordrtc",


### PR DESCRIPTION
The module cannot be imported using require and webpack because the "main" property is missing in the package.json.

This pull request just add the that property fixing the issue with webpack.