### PR TITLE
Update MultiStreamsMixer.js - About appendStreams function

### DIFF
--- a/MultiStreamsMixer/MultiStreamsMixer.js
+++ b/MultiStreamsMixer/MultiStreamsMixer.js
@@ -476,6 +476,13 @@ function MultiStreamsMixer(arrayOfMediaStreams, elementClass) {
             if (stream.getTracks().filter(function(t) {
                     return t.kind === 'audio';
                 }).length) {
+                
+                if (!Storage.AudioContextConstructor) {
+                    Storage.AudioContextConstructor = new Storage.AudioContext();
+                }
+
+                self.audioContext = Storage.AudioContextConstructor;
+                
                 var audioSource = self.audioContext.createMediaStreamSource(stream);
                 // self.audioDestination = self.audioContext.createMediaStreamDestination();
                 audioSource.connect(self.audioDestination);

--- a/MultiStreamsMixer/MultiStreamsMixer.js
+++ b/MultiStreamsMixer/MultiStreamsMixer.js
@@ -484,7 +484,7 @@ function MultiStreamsMixer(arrayOfMediaStreams, elementClass) {
                 self.audioContext = Storage.AudioContextConstructor;
                 
                 var audioSource = self.audioContext.createMediaStreamSource(stream);
-                // self.audioDestination = self.audioContext.createMediaStreamDestination();
+                self.audioDestination = self.audioContext.createMediaStreamDestination();
                 audioSource.connect(self.audioDestination);
 
                 newStream.addTrack(self.audioDestination.stream.getTracks().filter(function(t) {


### PR DESCRIPTION
Hi forks,

I have an issue when try to init a new MultiStreamsMixer with an empty array stream at constructor.
Then I append some streams via "appendStreams" function with the config "audio: true" => error, because it uses "audioContext" but not init anywhere. 

My PR solution is "init audioContext before use".

Steps to reproduce:
+ Init a new MultiStreamsMixer with empty array streams.
+ Append streams(with audio config is true) via ".appendStreams".